### PR TITLE
fix GetSpellTexture shim

### DIFF
--- a/.pkgmeta
+++ b/.pkgmeta
@@ -3,15 +3,15 @@ enable-toc-creation: yes
 
 externals:
   Diminish_Options/libs/WardzConfigDropdown-1.0: https://github.com/wardz/WardzConfigDropdown-1.0
-  Diminish/libs/LibStub: https://github.com/wardz/LibStub
-  Diminish/libs/DRList-1.0: https://github.com/wardz/DRList-1.0
-
-move-folders:
-  Diminish/Diminish_Options: Diminish_Options
-  Diminish/Diminish: Diminish
+  Diminish/libs/LibStub: https://repos.wowace.com/wow/ace3/trunk/LibStub
+  Diminish/libs/DRList-1.0: https://github.com/wardz/DRList-1.0/tree/master/DRList-1.0
 
 ignore:
   - README.md
   - CHANGELOG.md
   - Diminish/libs/LibStub/LibStub.toc
-  - "Diminish/libs/DRList-1.0/DRList-1.0/*.toc"
+  - Diminish/libs/DRList-1.0/*.toc
+
+move-folders:
+  Diminish/Diminish_Options: Diminish_Options
+  Diminish/Diminish: Diminish

--- a/Diminish/core/icons.lua
+++ b/Diminish/core/icons.lua
@@ -582,7 +582,13 @@ function Icons:ReleaseFrame(frame, unitID, timer, category)
 end
 
 do
-    local GetSpellTexture = _G.GetSpellTexture
+    local GetSpellTexture = function(...)
+        if _G.GetSpellTexture then
+            return _G.GetSpellTexture(...)
+        elseif C_Spell and C_Spell.GetSpellTexture then
+            return C_Spell.GetSpellTexture(...)
+        end
+    end
     local CATEGORY_TAUNT = NS.CATEGORIES.taunt
     local indicatorColors = NS.DR_STATES_COLORS
     local DR_TIME = NS.DR_TIME
@@ -623,7 +629,7 @@ do
             return frame.icon:SetTexture(NS.db.categoryTextures[timer.category])
         end
 
-        frame.icon:SetTexture(C_Spell.GetSpellTexture(timer.spellID))
+        frame.icon:SetTexture(GetSpellTexture(timer.spellID))
     end
 
     function Icons:StartCooldown(timer, unitID, onAuraEnd)

--- a/Diminish_Options/frames.lua
+++ b/Diminish_Options/frames.lua
@@ -223,6 +223,13 @@ for unitFrame, unit in pairs(NS.unitFrames) do
         -------------------------------------------------------------------
 
         do
+            local GetSpellTexture = function(...)
+                if _G.GetSpellTexture then
+                    return _G.GetSpellTexture(...)
+                elseif C_Spell and C_Spell.GetSpellTexture then
+                    return C_Spell.GetSpellTexture(...)
+                end
+            end
             local subCategories = Widgets:CreateSubHeader(panel, L.HEADER_CATEGORIES)
             subCategories:SetPoint("RIGHT", -64, 10)
 
@@ -245,7 +252,7 @@ for unitFrame, unit in pairs(NS.unitFrames) do
                         return
                     end
 
-                    local texture = C_Spell.GetSpellTexture(text)
+                    local texture = GetSpellTexture(text)
                     if texture then
                         DIMINISH_NS.db.categoryTextures[self.category] = texture
                     else
@@ -279,7 +286,7 @@ for unitFrame, unit in pairs(NS.unitFrames) do
                     frames.iconPreview:SetParent(nil)
                 end,
                 EditBoxOnTextChanged = function(editbox)
-                    local texture = C_Spell.GetSpellTexture(editbox:GetText())
+                    local texture = GetSpellTexture(editbox:GetText())
                     if texture then
                         frames.iconPreview.icon:SetTexture(texture)
                         editbox:GetParent().button1:Enable()


### PR DESCRIPTION
As it says on the title.
This errors on some wow clients as C_Spell.GetSpellTexture does not exist.
Conversely the upvalue of _G.GetSpellTexture is not used.

This PR makes it so it will work in both cases.